### PR TITLE
Added a NoopFileLocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## v1.0.1
+Added a NoopFileLocator to prevent errors when installing the bundle.
+
 ## v1.0.0
 Initial release

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,5 +16,8 @@ services:
 
   MintwareDe\NativeCron\CrontabManager:
 
+  MintwareDe\NativeCron\Filesystem\CrontabFileLocatorInterface:
+    class: MintwareDe\NativeCronBundle\Filesystem\NoopFileLocator
+
   MintwareDe\NativeCron\Filesystem\FileHandlerInterface:
     class: MintwareDe\NativeCron\Filesystem\FileHandler

--- a/src/Filesystem/NoopFileLocator.php
+++ b/src/Filesystem/NoopFileLocator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MintwareDe\NativeCronBundle\Filesystem;
+
+use MintwareDe\NativeCron\Filesystem\CrontabFileLocatorInterface;
+
+class NoopFileLocator implements CrontabFileLocatorInterface
+{
+    public const EXCEPTION_MSG = 'You need to specify a CrontabFileLocatorInterface. Check the README at https://github.com/mintware-de/native-cron-bundle.';
+
+    public function locateDropInCrontab(string $name): string
+    {
+        throw new \Exception(self::EXCEPTION_MSG);
+    }
+
+    public function locateUserCrontab(string $username): string
+    {
+        throw new \Exception(self::EXCEPTION_MSG);
+    }
+
+    public function locateSystemCrontab(): string
+    {
+        throw new \Exception(self::EXCEPTION_MSG);
+    }
+}

--- a/tests/Filesystem/NoopFileLocatorTest.php
+++ b/tests/Filesystem/NoopFileLocatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MintwareDe\NativeCronBundle\Tests\Filesystem;
+
+use MintwareDe\NativeCron\Filesystem\CrontabFileLocatorInterface;
+use MintwareDe\NativeCronBundle\Filesystem\NoopFileLocator;
+use PHPUnit\Framework\TestCase;
+
+class NoopFileLocatorTest extends TestCase
+{
+    private NoopFileLocator $locator;
+
+    public function setUp(): void
+    {
+        $this->locator = new NoopFileLocator();
+        self::assertInstanceOf(CrontabFileLocatorInterface::class, $this->locator);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage(NoopFileLocator::EXCEPTION_MSG);
+    }
+
+    public function testLocateDropInCrontabShouldThrow(): void
+    {
+        $this->locator->locateDropInCrontab('');
+    }
+
+    public function testLocateUserCrontabShouldThrow(): void
+    {
+        $this->locator->locateUserCrontab('');
+    }
+
+    public function testLocateSystemCrontabShouldThrow(): void
+    {
+        $this->locator->locateSystemCrontab();
+    }
+}


### PR DESCRIPTION
The NoopFileLocator will be used as the default MintwareDe\NativeCron\Filesystem\CrontabFileLocatorInterface. 

This will fix this error when installing the bundle:
```
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In DefinitionErrorExceptionPass.php line 54:
!!                                                                                 
!!    Cannot autowire service "MintwareDe\NativeCron\CrontabManager": argument "$  
!!    fileLocator" of method "__construct()" references interface "MintwareDe\Nat  
!!    iveCron\Filesystem\CrontabFileLocatorInterface" but no such service exists.  
!!  
!!  
```